### PR TITLE
Fix typo in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vale-boilerplate
 
-This is an repository showcases the basic components of Vale's configuration: a `StylesPath` (`/styles`), a configuration file (`/.vale.ini`), and markup content (this file).
+This repository showcases the basic components of Vale's configuration: a `StylesPath` (`/styles`), a configuration file (`/.vale.ini`), and markup content (this file).
 
 Try it out by running `vale README.md` from your command line.
 


### PR DESCRIPTION
This fixes a minor typo in the first sentence of the README.

In contrast to the intentional errors later in the file, Vale doesn't catch this, and it doesn't seem to be intended as an illustration of Vale's abilities, so I assume it's an oversight.

Thanks for providing this as a starting point for new styles. 🙏 